### PR TITLE
fix sql error when $params['order'] is empty in get_photolist()

### DIFF
--- a/xoops_trust_path/modules/d3diary/class/func.class.php
+++ b/xoops_trust_path/modules/d3diary/class/func.class.php
@@ -1225,6 +1225,7 @@ function get_photolist( $req_uid=array(), $uid, $max_entry, $offset=0, $params=a
 			$whr_nofuture = "";
 		}
 
+	$whr_pid = "" ;
 	$whr_cid = "" ;
 	$whr_cat = "" ;
 	$whr_tag = "" ;
@@ -1266,6 +1267,9 @@ function get_photolist( $req_uid=array(), $uid, $max_entry, $offset=0, $params=a
 
 		$ofst_key = !empty($params['ofst_key']) ? $params['ofst_key'] : "phofst";
 
+		if(!empty($params['pid'])){
+			$whr_pid = " AND p.pid = '".$params['pid']."'" ;
+		}
 		if(!empty($params['cids'])){
 			if( $params['cids'][0] == 0 ) {
 				$whr_cid = " AND c.cid IS NULL " ;
@@ -1317,34 +1321,35 @@ function get_photolist( $req_uid=array(), $uid, $max_entry, $offset=0, $params=a
 			LEFT JOIN ".$db->prefix($this->mydirname.'_category')." c ".$on_uid." 
 			LEFT JOIN ".$db->prefix($this->mydirname.'_config')." cfg ON d.uid=cfg.uid 
 			".$table_tag."
-			WHERE ".$whr_uids.$whr_openarea.$whr_nofuture.$whr_cid.$whr_cat.$whr_tag.$whr_time.$odr ;
+			WHERE ".$whr_uids.$whr_openarea.$whr_nofuture.$whr_pid.$whr_cid.$whr_cat.$whr_tag.$whr_time.$odr ;
 
 	// get total photos count
-	$sql = "SELECT count(p.pid) as count ".$sql_base ;
-	$result = $db->query($sql);
-	list ($count) = $db->fetchRow($result);
-	if($max_entry && $count>$max_entry){
-            if( !empty($_SERVER['QUERY_STRING'])) {
-                if( preg_match("/^".$ofst_key."=[0-9]+/", $_SERVER['QUERY_STRING']) ) {
-                    $url = "";
-                } else {
-                    $url = preg_replace("/^(.*)\&".$ofst_key."=[0-9]+/", "$1", $_SERVER['QUERY_STRING']);
-                }
-            } else {
-                $url = "";
-            }
-	    include_once dirname( dirname(__FILE__) ).'/class/d3diaryPagenavi.class.php';
-            $nav = new d3diaryPageNav($count, $max_entry, $offset, $ofst_key, $url);
-            if (!empty($params['getnav'])) {
-        	$got_navi = $nav->getNav();
-         	$got_navi['count'] = $count ;
-          } else {
-        	$got_navi = $nav->renderNav();
-             }
-        } else {
-            $got_navi = array();
-        }
-
+	$got_navi = array();
+	if ($max_entry) {
+		$sql = "SELECT count(p.pid) as count ".$sql_base ;
+		$result = $db->query($sql);
+		list ($count) = $db->fetchRow($result);
+		if($count>$max_entry){
+			if( !empty($_SERVER['QUERY_STRING'])) {
+				if( preg_match("/^".$ofst_key."=[0-9]+/", $_SERVER['QUERY_STRING']) ) {
+					$url = "";
+				} else {
+					$url = preg_replace("/^(.*)\&".$ofst_key."=[0-9]+/", "$1", $_SERVER['QUERY_STRING']);
+				}
+			} else {
+				$url = "";
+			}
+			include_once dirname( dirname(__FILE__) ).'/class/d3diaryPagenavi.class.php';
+			$nav = new d3diaryPageNav($count, $max_entry, $offset, $ofst_key, $url);
+			if (!empty($params['getnav'])) {
+				$got_navi = $nav->getNav();
+				$got_navi['count'] = $count ;
+			} else {
+				$got_navi = $nav->renderNav();
+			}
+		}
+	}
+	
 	$sql = "SELECT p.pid as pid, p.ptype as ptype, p.tstamp as tstamp, p.info as info, p.bid as bid, p.uid as uid, 
 			title, uname, name "
 			.$sql_base ;
@@ -1913,7 +1918,7 @@ function update_other(){
 		$uid    = intval($line['uid']);
 		$cid    = 0;
 
-		# ��
+		# 鐃緒申
 		$query = "DELETE FROM ".$db->prefix($this->mydirname.'_newentry')." WHERE uid='".$uid
 			."' AND cid='".$cid."'";
 		$result2 = $db->queryF($query);
@@ -1932,7 +1937,7 @@ function update_other(){
 	    	$yd_data['link'] = $item['link'];
 	    	$yd_data['blogtype'] = $line['blogtype'];
 		
-			# ����se��ɦ����
+			# 鐃緒申鐃緒申se鐃緒申髭鐃緒申鐃緒申
 			if(!empty($item['dc']['date'])){
 				$tstamp=strtotime($item['dc']['date']);
 			}elseif(!empty($item['pubdate'])){
@@ -1978,7 +1983,7 @@ function update_other(){
 						)";
 			$result2 = $db->queryF($query);
 	
-			# �飨��ȥ꣪
+			# 鐃初�鐃緒申肇蝪�
 			break;
 		}
 	}
@@ -2005,7 +2010,7 @@ function update_other_cat($uid){
 		//$uid    = intval($line['uid']);
 		$cid = intval($line['cid']);
 
-		# ��
+		# 鐃緒申
 		$query = "DELETE FROM ".$db->prefix($this->mydirname.'_newentry')." WHERE uid='".$uid
 			."' AND cid='".$cid."'";
 		$result2 = $db->queryF($query);
@@ -2025,7 +2030,7 @@ function update_other_cat($uid){
 	    		$yd_data['blogtype'] = $line['blogtype'];
 			//var_dump($cid); var_dump($yd_data['title'] ); echo"<br />";
 
-			# ����se��ɦ����
+			# 鐃緒申鐃緒申se鐃緒申髭鐃緒申鐃緒申
 			if(!empty($item['dc']['date'])){
 				$tstamp=strtotime($item['dc']['date']);
 			}elseif(!empty($item['pubdate'])){
@@ -2072,7 +2077,7 @@ function update_other_cat($uid){
 						)";
 			$result2 = $db->queryF($query);
 	
-			# �飨��ȥ꣪
+			# 鐃初�鐃緒申肇蝪�
 			break;
 		}
 	}


### PR DESCRIPTION
X-elFinder のドライバを準備していて order をセットする必要がないので気づきました。
get_photolist() で $params['order'] がセットされていないと SQL エラーになる問題の修正をしてみました。
