### PR TITLE
add "public static" to `getInstance()`

### DIFF
--- a/xoops_trust_path/modules/d3diary/class/category.class.php
+++ b/xoops_trust_path/modules/d3diary/class/category.class.php
@@ -19,7 +19,7 @@ class D3diaryCategory
 	public function __construct(){
 	}
 
-    function &getInstance()
+    public static function &getInstance()
     {
         static $instance;
         if (!isset($instance)) {

--- a/xoops_trust_path/modules/d3diary/class/d3diaryConf.class.php
+++ b/xoops_trust_path/modules/d3diary/class/d3diaryConf.class.php
@@ -301,7 +301,7 @@ function execute( $request )
 	// abstract (must override it)
 }
 
-function & getInstance($mydirname, $req_uid=0, $caller="")
+public static function & getInstance($mydirname, $req_uid=0, $caller="")
 {
 	static $instance ;
 	if( ! isset( $instance[$mydirname] ) ) {

--- a/xoops_trust_path/modules/d3diary/class/diary.class.php
+++ b/xoops_trust_path/modules/d3diary/class/diary.class.php
@@ -20,7 +20,7 @@ class D3diaryDiary
 	public function __construct(){
 	}
 
-    function &getInstance()
+    public static function &getInstance()
     {
         static $instance;
         if (!isset($instance)) {

--- a/xoops_trust_path/modules/d3diary/class/photo.class.php
+++ b/xoops_trust_path/modules/d3diary/class/photo.class.php
@@ -15,7 +15,7 @@ class D3diaryPhoto
 	public function __construct(){
 	}
 
-    function &getInstance()
+    public static function &getInstance()
     {
         static $instance;
         if (!isset($instance)) {

--- a/xoops_trust_path/modules/d3diary/class/tag.class.php
+++ b/xoops_trust_path/modules/d3diary/class/tag.class.php
@@ -14,7 +14,7 @@ class D3diaryTag
 	public function __construct(){
 	}
 
-    function &getInstance()
+    public static function &getInstance()
     {
         static $instance;
         if (!isset($instance)) {


### PR DESCRIPTION
To fix PHP error "Deprecated [PHP]: Non-static method (class)::getInstance() should not be called statically"

誰かが d3Diary
を継承してなんらかのカスタマイズを行っている場合は、この修正方法だと敬称クラスとの齟齬ができてしまいますが、それを考慮しない修正案です。